### PR TITLE
Add support for --config with JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ node index.js --input <folder>
 node index.js -i <folder>
 ```
 
-The --input/-i flag is required, followed by a path to either an existing text/markdown file or folder containing multiple files. The contents of each file will be converted into an HTML file with the same name and stored in the output directory specified or in the 'dist' directory if no output directory is specified. If a folder contains non-text/markdown files, these files will not be converted into HTML. 
+The input path to either an existing text/markdown file or a folder containing multiple files is required. Please specify the input path using the `--input/-i` flag or by adding it as `"input"` in a JSON config file.
+
+The contents of each file will be converted into an HTML file with the same name and stored in the output directory specified or in the 'dist' directory if no output directory is specified. If a folder contains non-text/markdown files, these files will not be converted into HTML. 
 
 # Optional Flags
 
@@ -42,6 +44,24 @@ The --input/-i flag is required, followed by a path to either an existing text/m
 | `--output/-o <folder>` | Path to an output directory where generated pages will be stored  |
 | `--stylesheet/-s <URL>`  | Stylesheet URL to be used to style the generated pages  |
 | `--lang <string>` | The lang attribute for the ```<html>``` tag of each page, describes the language of a page, set to 'en-CA' by default |
+
+ # JSON Config File
+
+ Instead of passing options as flags, a path to a JSON config file can be provided. This JSON file needs to contain at least "input" with the path to the file or folder.
+
+ | Flag  | Description |
+| ------------- | ------------- |
+| `--config/-c <file.json>` | Path to a JSON config file than contains other options |
+
+Example JSON file
+
+```json
+{
+  "input": "Sherlock-Holmes-Selected-Stories",
+  "output": "./web",
+  "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
+}
+```
 
 # Getting Help
 

--- a/index.js
+++ b/index.js
@@ -168,17 +168,6 @@ const getUserInput = (argv) => {
 
     if (argv.input) {
         input = argv.input.join(' ');
-        // Setting the output directory
-        if (argv.output && !fs.existsSync(argv.output)) {
-            console.error('Invalid output argument entered.');
-            return false;
-        } else {
-            argv.output = 'dist';
-        }
-        // Setting the stylesheet
-        if (!argv.stylesheet) {
-            argv.stylesheet = 'style.css';
-        }
     }
 
     if(argv.config && fs.existsSync(argv.config)) {
@@ -192,6 +181,21 @@ const getUserInput = (argv) => {
             console.error('Config file needs to be a JSON file');
             return false;
         }
+    } else {
+        console.log('JSON config file is required');
+        return false;
+    }
+
+    // Setting the output directory
+    if (argv.output && !fs.existsSync(argv.output)) {
+        console.error('Invalid output argument entered.');
+        return false;
+    } else {
+        argv.output = 'dist';
+    }
+    // Setting the stylesheet
+    if (!argv.stylesheet) {
+        argv.stylesheet = 'style.css';
     }
 
     // Setting the input

--- a/index.js
+++ b/index.js
@@ -163,14 +163,14 @@ const writeIndexPage = (argv, input) => {
  * @return {boolean} => returns true if the user input is valid (valid input and output directory) 
  */
 const getUserInput = (argv) => {
-    let input = ""; 
+    let input = ''; 
     let filesArray = [];
 
     if (argv.input) {
         input = argv.input.join(' ');
         // Setting the output directory
         if (argv.output && !fs.existsSync(argv.output)) {
-            console.error("Invalid output argument entered.");
+            console.error('Invalid output argument entered.');
             return false;
         } else {
             argv.output = 'dist';
@@ -182,16 +182,21 @@ const getUserInput = (argv) => {
     }
 
     if(argv.config && fs.existsSync(argv.config)) {
-        // Get options from json file and save them in argv  
-        argv = jsonfile.readFileSync(argv.config, (err) => {
-            if (err) console.error(err);
-        })
-        input = argv.input;
+        if (fs.statSync(argv.config).isFile() && path.extname(input) == '.json') {
+            // Get options from json file and save them in argv  
+            argv = jsonfile.readFileSync(argv.config, (err) => {
+                if (err) console.error(err);
+            })
+            input = argv.input;
+        } else {
+            console.error('Config file needs to be a JSON file');
+            return false;
+        }
     }
 
     // Setting the input
     if (!input || !fs.existsSync(input)) {
-        console.error("Input file or folder is required");
+        console.error('Input file or folder is required');
         return false;
     } else {
         if (fs.statSync(input).isFile() && (path.extname(input) == '.txt' || path.extname(input) == '.md')) {
@@ -231,7 +236,7 @@ const main = () => {
         .alias('v', 'version')
         .option('config', {
             alias: 'c',
-            describe: 'Use a JSON config file',
+            describe: 'Path to a JSON config file',
             type: 'string'
         })
         .options('input', {

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ const getUserInput = (argv) => {
     }
 
     if(argv.config && fs.existsSync(argv.config)) {
-        if (fs.statSync(argv.config).isFile() && path.extname(input) == '.json') {
+        if (fs.statSync(argv.config).isFile() && path.extname(argv.config) == '.json') {
             // Get options from json file and save them in argv  
             argv = jsonfile.readFileSync(argv.config, (err) => {
                 if (err) console.error(err);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "Leyang Yu",
   "license": "MIT",
   "dependencies": {
+    "jsonfile": "^6.1.0",
     "yargs": "^17.1.1"
   }
 }


### PR DESCRIPTION
Fixes #15 

This PR adds a `--config` option to specify all of the other SSG options in a JSON formatted configuration file.

### Example:

`node index.js --config options.json`

where options.json is equal to:
```
{
  "input": "./docs",
  "output": "./web"
}
```
would be the equivalent of doing `node index.js -i ./docs -o ./web`

---
I still need to update the README to document the changes.